### PR TITLE
Update __init__.py

### DIFF
--- a/opusdsd/__init__.py
+++ b/opusdsd/__init__.py
@@ -90,7 +90,8 @@ class Plugin(pwem.Plugin):
         # try to get CONDA activation command
         installCmds = [
             cls.getCondaActivationCmd(),
-            f'conda env create --name {ENV_NAME} --file environment.yml --force &&',
+            f'conda env create --name {ENV_NAME} --file environment.yml &&',
+            #f'conda env update --name {ENV_NAME} --file environment.yml --force &&',
             f'conda activate {ENV_NAME} &&',
             f'touch {FLAG}'  # Flag installation finished
         ]


### PR DESCRIPTION
In recent versions of conda, the --force command is not valid anymore with conda env create. It needs to be removed so that users can properly install the plugin. Also, there's another way using conda env update, which allows using that command.